### PR TITLE
feat(forward): forward calls for which no mocked data is available

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import minimatch from 'minimatch';
 import path from 'path';
-import { Application, Request, Response } from 'express';
+import { Application, NextFunction, Request, Response } from 'express';
 import { IFixtureConfig, IRule } from './contracts';
 
 const DEFAULT_METHOD = 'GET';
@@ -9,7 +9,7 @@ export function MockDevServer(configPath: string = './mock-dev-server.config') {
   const fixtureConfig: IFixtureConfig = require(configPath);
 
   return function DevServerBefore(app: Application) {
-    app.all(fixtureConfig.entry || '*', function (req: Request, res: Response) {
+    app.all(fixtureConfig.entry || '*', function (req: Request, res: Response, next: NextFunction) {
       const { method, originalUrl } = req;
       const rule = getRule(req);
 
@@ -18,6 +18,7 @@ export function MockDevServer(configPath: string = './mock-dev-server.config') {
         setResponseBody(res, rule);
       } else {
         console.warn(`No rule found for ${method} '${originalUrl}'`);
+        next();
       }
     });
   };


### PR DESCRIPTION
This commit makes mocking transparent and just forwards calls for which no fixtures are defined, thus it allows for seamless integration with an existing backend. It lets you mock specific endpoints only, i.e. an endpoint that is under development at the time when the frontend parts are getting implemented, while keeping existing functionality.