### PR TITLE
Webpack-dev-server v4 migration fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,11 +5,15 @@ import { IFixtureConfig, IRule } from './contracts';
 
 const DEFAULT_METHOD = 'GET';
 
+interface DevServer {
+  app: Application
+}
+
 export function MockDevServer(configPath: string = './mock-dev-server.config') {
   const fixtureConfig: IFixtureConfig = require(configPath);
 
-  return function DevServerBefore(app: Application) {
-    app.all(fixtureConfig.entry || '*', function (req: Request, res: Response, next: NextFunction) {
+  return function DevServerBefore(devServer: DevServer) {
+    devServer.app.all(fixtureConfig.entry || '*', function (req: Request, res: Response, next: NextFunction) {
       const { method, originalUrl } = req;
       const rule = getRule(req);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-mock-dev-server",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "description": "Mocks webpack dev server request in an easy configurable way",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
In order to make webpack-mock-dev-server work with v4 of webpack-dev-server a minor change needs to be made.

See https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md
and find 'The before option was renamed to onBeforeSetupMiddleware and changed arguments.'